### PR TITLE
React 전역 인증 상태 관리

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,8 +1,13 @@
 // src/ProtectedRoute.jsx
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "./context/AuthContext";
 
 export default function ProtectedRoute() {
   const { isAuth } = useAuth();
-  return isAuth ? <Outlet /> : <Navigate to="/login" replace />;
+  const location = useLocation();
+  return isAuth ? (
+    <Outlet />
+  ) : (
+    <Navigate to="/login" replace state={{ from: location }} />
+  );
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, Navigate } from "react-router-dom";
+import { useNavigate, Navigate, useLocation } from "react-router-dom";
 import Button from "../components/Button";
 import Input from "../components/Input";
 import Title from "../components/Title";
@@ -10,9 +10,11 @@ export default function Login() {
   const [uId, setUId] = useState("");
   const [uPwd, setUPwd] = useState("");
   const navigate = useNavigate();
+  const location = useLocation();
 
-  // 이미 로그인 상태라면 홈으로 보냄
-  if (isAuth) return <Navigate to="/record" replace />;
+  // 이미 로그인 상태라면 원래 가려던 곳 또는 기본 페이지로 보냄
+  const fromPath = location.state?.from?.pathname || "/record-list";
+  if (isAuth) return <Navigate to={fromPath} replace />;
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -22,7 +24,7 @@ export default function Login() {
     }
     try {
       await login(uId, uPwd);   // Context의 login 함수 호출 → 세션 저장
-      navigate("/");            // 로그인 성공 후 홈으로 이동
+      navigate(fromPath, { replace: true });
     } catch {
       alert("로그인 실패");
     }


### PR DESCRIPTION
Fix login redirect to navigate to the intended page instead of always `/record` or `/`.

The previous implementation hard-coded redirects to `/record` or `/` after login or when already authenticated. This PR modifies `ProtectedRoute.jsx` to pass the attempted URL to the login page and `Login.jsx` to read this URL and redirect the user there after successful authentication, improving user experience by returning them to their original destination.

---
<a href="https://cursor.com/background-agent?bcId=bc-980244e4-6b7f-40b9-bfec-782de1d5f610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-980244e4-6b7f-40b9-bfec-782de1d5f610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

